### PR TITLE
got mariadb service to stay running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ MAINTAINER ilari.makela@wunderkraut.com
 # Update the package repository and install applications
 RUN apk --no-cache --update add mariadb && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/* && \
-    mysql_install_db
+    rm -rf /var/cache/apk/*
 
-VOLUME /var/lib/mysql
+RUN mysql_install_db && \
+    chown -R mysql /var/lib/mysql
+
 VOLUME /var/log/mysql
 
 # Expose port 3306


### PR DESCRIPTION
I AM NOT 100% CERTAIN ABOUT THESE CHANGES YET

The following changes were required:
1. Change permissions on mysql lib to allow mysql user to write to the fodler
2. leave the data folder as outside a volume (allow permssion changes to persist)
- number #2 also means that image snapshots will include the data path.
