### PR TITLE
Fix Maria startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk --no-cache --update add mariadb && \
 RUN mysql_install_db && \
     chown -R mysql /var/lib/mysql
 
+VOLUME /var/lib/mysql
 VOLUME /var/log/mysql
 
 # Expose port 3306

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ MAINTAINER ilari.makela@wunderkraut.com
 # Update the package repository and install applications
 RUN apk --no-cache --update add mariadb && \
     rm -rf /tmp/* && \
-    rm -rf /var/cache/apk/* && \
-    mysql_install_db
+    rm -rf /var/cache/apk/*
 
-VOLUME /var/lib/mysql
+RUN mysql_install_db && \
+    chown -R mysql /var/lib/mysql
+
 VOLUME /var/log/mysql
 
 # Expose port 3306


### PR DESCRIPTION
The mariadb startup was failing due to user permissions in the /var/lib/mysql folder.  I also separated the run for package install, and db install.  This should cause no significant increase in image size, but that should be verified.
